### PR TITLE
Fix gcc build

### DIFF
--- a/Plouton-UEFI/Dockerfile
+++ b/Plouton-UEFI/Dockerfile
@@ -4,4 +4,4 @@ MAINTAINER Jussi Hietanen
 RUN \
 	apt-get update && \
 	apt-get -y install ccache build-essential python python-pip qemu sudo git \
-			nano libgcc-5-dev uuid-dev nasm iasl wget zip xorg-dev p7zip-full
+			nano libgcc-5-dev uuid-dev nasm iasl wget zip xorg-dev p7zip-full bear

--- a/Plouton-UEFI/Plouton/hardware/audio/audioDriver.h
+++ b/Plouton-UEFI/Plouton/hardware/audio/audioDriver.h
@@ -15,7 +15,7 @@ typedef struct _audioProfile {
 
 // Define function pointer types
 #ifdef __GNUC__
-typedef audioProfile_t EFIAPI (*InitAudioDriverFun)(VOID);
+typedef audioProfile_t EFIAPI (*InitAudioDriverFun)(EFI_PHYSICAL_ADDRESS);
 #else
 typedef audioProfile_t (*InitAudioDriverFun)(EFI_PHYSICAL_ADDRESS);
 #endif

--- a/Plouton-UEFI/Plouton/hardware/audio/corsair_wireless.c
+++ b/Plouton-UEFI/Plouton/hardware/audio/corsair_wireless.c
@@ -16,7 +16,7 @@
 *  returns:	The audioProfile struct, initialized set As TRUE if it was found
 *
 */
-audioProfile_t initCorsairWirelessAudioXHCI(EFI_PHYSICAL_ADDRESS MBAR)
+audioProfile_t EFIAPI initCorsairWirelessAudioXHCI(EFI_PHYSICAL_ADDRESS MBAR)
 {
 	// This implementation is based on the following documents:
 	// - Intel 600 series datasheet see: https://www.intel.com/content/www/us/en/content-details/742460/intel-600-series-chipset-family-for-iot-edge-platform-controller-hub-pch-datasheet-volume-2-of-2.html

--- a/Plouton-UEFI/Plouton/hardware/audio/creative_usb_speakers.c
+++ b/Plouton-UEFI/Plouton/hardware/audio/creative_usb_speakers.c
@@ -16,7 +16,7 @@
 *  returns:	The audioProfile struct, initialized set As TRUE if it was found
 *
 */
-audioProfile_t initCreativeUsbSpeakersAudioXHCI(EFI_PHYSICAL_ADDRESS MBAR)
+audioProfile_t EFIAPI initCreativeUsbSpeakersAudioXHCI(EFI_PHYSICAL_ADDRESS MBAR)
 {
 	// This implementation is based on the following documents:
 	// - Intel 600 series datasheet see: https://www.intel.com/content/www/us/en/content-details/742460/intel-600-series-chipset-family-for-iot-edge-platform-controller-hub-pch-datasheet-volume-2-of-2.html

--- a/Plouton-UEFI/Plouton/hardware/audio/dummy.c
+++ b/Plouton-UEFI/Plouton/hardware/audio/dummy.c
@@ -12,7 +12,7 @@
 *  returns:	The audioProfile struct, initialized set As TRUE if it was found
 *
 */
-audioProfile_t initAudioXHCI(EFI_PHYSICAL_ADDRESS MBAR)
+audioProfile_t EFIAPI initAudioXHCI(EFI_PHYSICAL_ADDRESS MBAR)
 {
     audioProfile_t ret = { TRUE, 0, 0 };
     return ret;

--- a/Plouton-UEFI/Plouton/hardware/audio/hyperx_cloud_2.c
+++ b/Plouton-UEFI/Plouton/hardware/audio/hyperx_cloud_2.c
@@ -16,7 +16,7 @@
 *  returns:	The audioProfile struct, initialized set As TRUE if it was found
 *
 */
-audioProfile_t initHyperXCloud2AudioXHCI(EFI_PHYSICAL_ADDRESS MBAR)
+audioProfile_t EFIAPI initHyperXCloud2AudioXHCI(EFI_PHYSICAL_ADDRESS MBAR)
 {
 	// This implementation is based on the following documents:
 	// - Intel 600 series datasheet see: https://www.intel.com/content/www/us/en/content-details/742460/intel-600-series-chipset-family-for-iot-edge-platform-controller-hub-pch-datasheet-volume-2-of-2.html

--- a/Plouton-UEFI/Plouton/hardware/audio/logitech_g_pro_x_2_wireless.c
+++ b/Plouton-UEFI/Plouton/hardware/audio/logitech_g_pro_x_2_wireless.c
@@ -16,7 +16,7 @@
 *  returns:	The audioProfile struct, initialized set As TRUE if it was found
 *
 */
-audioProfile_t initLogitechGProX2AudioXHCI(EFI_PHYSICAL_ADDRESS MBAR)
+audioProfile_t EFIAPI initLogitechGProX2AudioXHCI(EFI_PHYSICAL_ADDRESS MBAR)
 {
 	// This implementation is based on the following documents:
 	// - Intel 600 series datasheet see: https://www.intel.com/content/www/us/en/content-details/742460/intel-600-series-chipset-family-for-iot-edge-platform-controller-hub-pch-datasheet-volume-2-of-2.html

--- a/Plouton-UEFI/Plouton/hardware/audio/logitech_g_pro_x_wireless.c
+++ b/Plouton-UEFI/Plouton/hardware/audio/logitech_g_pro_x_wireless.c
@@ -16,7 +16,7 @@
 *  returns:	The audioProfile struct, initialized set As TRUE if it was found
 *
 */
-audioProfile_t initLogitechGProXAudioXHCI(EFI_PHYSICAL_ADDRESS MBAR)
+audioProfile_t EFIAPI initLogitechGProXAudioXHCI(EFI_PHYSICAL_ADDRESS MBAR)
 {
 	// This implementation is based on the following documents:
 	// - Intel 600 series datasheet see: https://www.intel.com/content/www/us/en/content-details/742460/intel-600-series-chipset-family-for-iot-edge-platform-controller-hub-pch-datasheet-volume-2-of-2.html

--- a/Plouton-UEFI/docker_build.sh
+++ b/Plouton-UEFI/docker_build.sh
@@ -19,7 +19,10 @@ cp -r edk2-overrides/* edk2
 # Build EDK2 UEFI firmware image with Plouton
 pushd edk2
 . edksetup.sh
-build -DSMM_REQUIRE
+
+# We unfortunately need to remap the paths to host FS
+# So after building run: "sed -i "s|/root/edk2/|$(pwd)/edk2/|g" compile_commands.json"
+bear -o ../compile_commands.json build -DSMM_REQUIRE
 popd
 
 # Clean-up Plouton-related changes


### PR DESCRIPTION
GCC doesn't inconsistencies between function declaration and definition. Just added EFIAPI to all audio inits.

Besides that i've added bear for an automatically generated "compile_commands.json" usable for many LSPs.